### PR TITLE
Bug: bikeOdo for some bike names

### DIFF
--- a/hook/extension/js/processors/VacuumProcessor.js
+++ b/hook/extension/js/processors/VacuumProcessor.js
@@ -360,7 +360,7 @@ VacuumProcessor.prototype = {
             _.each($(data.responseText).find('div.gear>table>tbody>tr'), function(element) {
                 var bikeName = $(element).find('td').first().text().trim();
                 var bikeOdo = $(element).find('td').last().text().trim();
-                bikeOdoArray[btoa(bikeName)] = bikeOdo;
+                bikeOdoArray[btoa(unescape(encodeURIComponent(bikeName)))] = bikeOdo;
             });
 
             callback(bikeOdoArray);


### PR DESCRIPTION
If bike name contains UTF8 characters, bike odo display doesn't work - error in console:

> _Uncaught InvalidCharacterError: Failed to execute 'btoa' on 'Window': The string to be encoded contains characters outside of the Latin1 range._

**Fixed** - see:
http://stackoverflow.com/questions/23223718/failed-to-execute-btoa-on-window-the-string-to-be-encoded-contains-characte
